### PR TITLE
Fixed problems walking With statements, fixes locally-assigned for With/For statements

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -707,7 +707,7 @@
          [`(With [(,exprs ,names) ...] . ,body)
           (set-union 
            assigned-in-rest
-           (for/set ([n names] #:when n) n)
+           (apply set-union0 (map targets-in (filter identity names)))
            (locally-assigned body))]
          
          [`(Raise . ,_)

--- a/main.rkt
+++ b/main.rkt
@@ -502,7 +502,7 @@
           
           ; (With [<withitem>*] <stmt>*)
           [`(With ,withitems . ,body)
-           (list `(With ,@(map walk-withitem withitems) 
+           (list `(With ,(map walk-withitem withitems) 
                         ,@(walk-stmts body)))]
           
           ; (Raise) 

--- a/main.rkt
+++ b/main.rkt
@@ -503,7 +503,7 @@
           ; (With [<withitem>*] <stmt>*)
           [`(With ,withitems . ,body)
            (list `(With ,@(map walk-withitem withitems) 
-                        ,@(map walk-stmts body)))]
+                        ,@(walk-stmts body)))]
           
           ; (Raise) 
           [`(Raise)

--- a/main.rkt
+++ b/main.rkt
@@ -629,6 +629,12 @@
   
   
   (define (locally-assigned stmts)
+
+    (define (set-union0 . sets)
+      (if (null? sets)
+        (set)
+        (apply set-union sets)))
+
     (cond
       [(null? stmts)  (set)]
       [else
@@ -641,8 +647,8 @@
          (match target-expr
            [`(Name ,name)               (set name)]
            [`(Starred ,target)          (targets-in target)]
-           [`(Tuple . ,targets)         (apply set-union (map targets-in targets))]
-           [`(List . ,targets)          (apply set-union (map targets-in targets))]
+           [`(Tuple . ,targets)         (apply set-union0 (map targets-in targets))]
+           [`(List . ,targets)          (apply set-union0 (map targets-in targets))]
            [`(Attribute ,_ ,_)          (set)]
            [`(Subscript ,_ ,_)          (set)]
            


### PR DESCRIPTION
Some accidental unquote-splicing shenanigans and an extraneous call to map.
